### PR TITLE
Failed to collect dependencies at software.amazon.timestream:amazon-t…

### DIFF
--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -16,12 +16,12 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 
   <parent>
     <groupId>software.amazon.timestream</groupId>
     <artifactId>timestream</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
   </parent>
 
   <artifactId>integrationtest</artifactId>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -15,13 +15,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>software.amazon.timestream</groupId>
-        <artifactId>timestream</artifactId>
-        <version>1.0.0</version>
-    </parent>
-
+    <groupId>software.amazon.timestream</groupId>
     <artifactId>amazon-timestream-jdbc</artifactId>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <distributionManagement>
@@ -36,6 +32,11 @@
     </distributionManagement>
 
     <properties>
+        <!-- Optionally specify a compiler here, we chose Java 8 -->
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <!-- Version properties are written out to be picked up by the driver. -->
         <driver.major.version>0</driver.major.version>
         <driver.minor.version>1</driver.minor.version>
@@ -44,36 +45,52 @@
 
         <!-- Set the timezone information for unit tests. -->
         <argLine>-Duser.timezone=Europe/Paris</argLine>
+
+        <!-- Dependency versions -->
+        <awssdk.version>1.11.870</awssdk.version>
+        <guava.version>28.0-jre</guava.version>
+        <junit.jupiter.version>5.6.2</junit.jupiter.version>
+        <jsoup.version>1.13.1</jsoup.version>
+        <mockito.version>2.28.2</mockito.version>
+        <slf4j.version>1.7.24</slf4j.version>
+        <timestream.version>1.11.872</timestream.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-timestreamquery</artifactId>
+            <version>${timestream.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/performancetest/pom.xml
+++ b/performancetest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>software.amazon.timestream</groupId>
     <artifactId>timestream</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
   </parent>
 
   <artifactId>performancetest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>software.amazon.timestream</groupId>
   <artifactId>timestream</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
…imestream-jdbc:jar:1.0.0

The jdbc/pom.xml has a reference to a parent pom as below

software.amazon.timestream
timestream
1.0.0
However the parent pom has not been uploaded to Maven Central (not necessary) and hence any applications depending upon amazon-timestream-jdbc fails with the following build error

[ERROR] Failed to execute goal on project TestSampleJDBCV1: Could not resolve dependencies for project software.amazon.timestream:TestSampleJDBCV1:jar:1.0-SNAPSHOT: Failed to collect dependencies at software.amazon.timestream:amazon-timestream-jdbc:jar:1.0.0: Failed to read artifact descriptor for software.amazon.timestream:amazon-timestream-jdbc:jar:1.0.0: Could not find artifact software.amazon.timestream:timestream:pom:1.0.0 in central (https://repo.maven.apache.org/maven2) -> [Help 1].

The fix is to remove the parent pom section from jdbc/pom.xml

*Issue #, if available:* https://github.com/awslabs/amazon-timestream-driver-jdbc/issues/5

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
