### PR TITLE
Report database name as schema instead of catalog to resolve compatibility issues with Tableau

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,16 +444,15 @@ To use the JAR with no dependencies in a Java application, the following require
 Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract the Javadoc HTML files, use the following command: `jar -xvf amazon-timestream-jdbc-1.0.0-javadoc.jar`
 
 ### Known Issues
-1. Timestream does not support fully qualified table names. Tools like Tableau may not work as expected.
+1. Timestream does not support fully qualified table names.
 1. Timestream does not support the queries that contain ":" in the column aliases. Tools like Tableau may not work as expected.
 
 ### Caveats
-1. Timestream does not support `getSchemas`, which may affect the behaviour of some tools: 
-    1. SQuirreL SQL Client displays tables without database information.
-1. SQuirreL SQL Client does not support Rows and Arrays. Running a `SELECT` query that returns an Array or a Struct will result in `UnknownType<2,003>`/`UnknownType<2,002>`.
-1. SQLWorkbench/J does not support using `Database Explorer` to describe Timestream databases with an `underscore` in the name, e.g. `grafana_db`.
-1. SQLWorkbench/J does not display the array values within a `java.sql.Struct`, instead SQLWorkbench/J displays the array's base type, e.g.`com.tsshaded.amazonaws.services.timestreamquery.model.Row(DOUBLE, 2)` instead of `({1.3},2)`.
-1. Timestream JDBC driver only works with queries with fully qualified table names.
+1. Timestream JDBC driver supports `getSchemas` and does not support `getCatalogs`, so Tableau will show database as schemas instead of catalogs. 
+2. SQuirreL SQL Client does not support Rows and Arrays. Running a `SELECT` query that returns an Array or a Struct will result in `UnknownType<2,003>`/`UnknownType<2,002>`.
+3. SQLWorkbench/J does not support using `Database Explorer` to describe Timestream databases with an `underscore` in the name, e.g. `grafana_db`.
+4. SQLWorkbench/J does not display the array values within a `java.sql.Struct`, instead SQLWorkbench/J displays the array's base type, e.g.`com.tsshaded.amazonaws.services.timestreamquery.model.Row(DOUBLE, 2)` instead of `({1.3},2)`.
+5. Timestream JDBC driver only works with queries with fully qualified table names.
 
 ## License
 This library is licensed under the Apache 2.0 License.

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -16,12 +16,12 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <version>1.0.2</version>
+  <version>2.0.0</version>
 
   <parent>
     <groupId>software.amazon.timestream</groupId>
     <artifactId>timestream</artifactId>
-    <version>1.0.2</version>
+    <version>2.0.0</version>
   </parent>
 
   <artifactId>integrationtest</artifactId>

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -106,7 +106,7 @@ class DatabaseMetaDataIntegrationTest {
    * @throws SQLException the exception thrown
    */
   @ParameterizedTest
-  @ValueSource(strings = {"JDBC_%", "%_Integration%", "%Test_DB", "JDBC_Integration___Test_DB"})
+  @ValueSource(strings = {"JDBC_%", "%_Integration%", "%Test_DB", "JDBC_Integration___Test_DB", "JDBC!_Integration07!_Test!_DB' escape '!"})
   @DisplayName("Test retrieving database name JDBC_Integration07_Test_DB with pattern.")
   void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
     try (ResultSet schemas = metaData.getSchemas(null, schemaPattern)) {

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -67,17 +67,53 @@ class DatabaseMetaDataIntegrationTest {
     connection.close();
   }
 
+  /**
+   * Test getCatalogs returns empty ResultSet.
+   * @throws SQLException the exception thrown
+   */
   @Test
-  @DisplayName("Test retrieving all databases.")
+  @DisplayName("Test getCatalogs(). Empty result set should be returned")
   void testCatalogs() throws SQLException {
-    final List<String> databasesList = Arrays.asList(Constants.DATABASES_NAMES);
     final List<String> catalogsList = new ArrayList<>();
     try (ResultSet catalogs = metaData.getCatalogs()) {
       while (catalogs.next()) {
         catalogsList.add(catalogs.getString("TABLE_CAT"));
       }
     }
-    Assertions.assertTrue(catalogsList.containsAll(databasesList));
+    Assertions.assertTrue(catalogsList.isEmpty());
+  }
+
+  /**
+   * Test getSchemas returns the list of all databases.
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test retrieving all databases.")
+  void testSchemas() throws SQLException {
+    final List<String> databasesList = Arrays.asList(Constants.DATABASES_NAMES);
+    final List<String> schemasList = new ArrayList<>();
+    try (ResultSet schemas = metaData.getSchemas()) {
+      while (schemas.next()) {
+        schemasList.add(schemas.getString("TABLE_SCHEM"));
+      }
+    }
+    Assertions.assertTrue(schemasList.containsAll(databasesList));
+  }
+
+  /**
+   * Test getSchemas returns database "JDBC_Integration07_Test_DB" when given matching patterns.
+   * @param schemaPattern the schema pattern to be tested
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"JDBC_%", "%_Integration%", "%Test_DB"})
+  @DisplayName("Test retrieving database name JDBC_Integration07_Test_DB with pattern.")
+  void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
+    try (ResultSet schemas = metaData.getSchemas(null, schemaPattern)) {
+      while (schemas.next()) {
+        Assertions.assertEquals(Constants.DATABASE_NAME, schemas.getString("TABLE_SCHEM"));
+      }
+    }
   }
 
   @ParameterizedTest

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>software.amazon.timestream</groupId>
     <artifactId>amazon-timestream-jdbc</artifactId>
-    <version>1.0.2</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
     <name>amazon-timestream-jdbc</name>
     <description>AWS Timestream JDBC driver</description>
@@ -60,8 +60,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Version properties are written out to be picked up by the driver. -->
-        <driver.major.version>0</driver.major.version>
-        <driver.minor.version>1</driver.minor.version>
+        <driver.major.version>2</driver.major.version>
+        <driver.minor.version>0</driver.minor.version>
         <driver.hotfix.version>0</driver.hotfix.version>
         <driver.version>${project.version}</driver.version>
 

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
@@ -64,6 +64,11 @@ public class TimestreamColumnsResultSet extends TimestreamBaseResultSet {
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "IS_AUTOINCREMENT"),
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "IS_GENERATEDCOLUMN"));
 
+  /* Index of table schema value in the resultSet returned from getTables() */
+  private final int TABLE_SCHEM_INDX = 2;
+  /* Index of table name value in the resultSet returned from getTables() */
+  private final int TABLE_NAME_INDX = 3;
+
   private final TimestreamStatement statement;
   private ResultSet result;
   private final TimestreamTablesResultSet tablesResult;
@@ -134,8 +139,8 @@ public class TimestreamColumnsResultSet extends TimestreamBaseResultSet {
     }
 
     // Get the columns for the next table.
-    curDatabase = tablesResult.getString(2);
-    curTable = tablesResult.getString(3);
+    curDatabase = tablesResult.getString(TABLE_SCHEM_INDX);
+    curTable = tablesResult.getString(TABLE_NAME_INDX);
     result = statement.executeQuery(String.format("DESCRIBE \"%s\".\"%s\"", curDatabase, curTable));
 
     populateCurrentRows();

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
@@ -134,7 +134,7 @@ public class TimestreamColumnsResultSet extends TimestreamBaseResultSet {
     }
 
     // Get the columns for the next table.
-    curDatabase = tablesResult.getString(1);
+    curDatabase = tablesResult.getString(2);
     curTable = tablesResult.getString(3);
     result = statement.executeQuery(String.format("DESCRIBE \"%s\".\"%s\"", curDatabase, curTable));
 
@@ -168,8 +168,8 @@ public class TimestreamColumnsResultSet extends TimestreamBaseResultSet {
     for (int i = 1; i <= numColumns; ++i) {
       final int columnType = rsMeta.getColumnType(i);
       columns.add(new Row().withData(
-        createDatum(curDatabase),
         NULL_DATUM,
+        createDatum(curDatabase),
         createDatum(curTable),
         createDatum(rsMeta.getColumnName(i)),
         createDatum(columnType),

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -937,7 +937,7 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
 
   @Override
   public boolean supportsSchemasInDataManipulation() {
-    return false;
+    return true;
   }
 
   @Override

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -935,6 +935,10 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
     return false;
   }
 
+  /**
+   * Retrieves whether a schema name can be used in a data manipulation statement.
+   * @return true since functionality is supported
+   */
   @Override
   public boolean supportsSchemasInDataManipulation() {
     return true;

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -171,8 +171,9 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getCatalogs() throws SQLException {
-    return new TimestreamDatabasesResultSet(this.connection);
+  public ResultSet getCatalogs(){
+    LOGGER.debug("Catalogs are not supported. Returning an empty result set.");
+    return new TimestreamDatabasesResultSet();
   }
 
   @Override
@@ -187,11 +188,11 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getColumns(String catalog, String schemaNamePattern, String tableNamePattern,
+  public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern,
     String columnNamePattern) throws SQLException {
     return new TimestreamColumnsResultSet(
       connection,
-      catalog,
+      schemaPattern,
       tableNamePattern,
       convertPattern(columnNamePattern));
   }
@@ -467,15 +468,13 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getSchemas() {
-    LOGGER.debug("Schemas are not supported. Returning an empty result set.");
-    return new TimestreamSchemasResultSet();
+  public ResultSet getSchemas() throws SQLException {
+    return new TimestreamSchemasResultSet(this.connection, null);
   }
 
   @Override
-  public ResultSet getSchemas(String catalog, String schemaPattern) {
-    LOGGER.debug("Schemas are not supported. Returning an empty result set.");
-    return new TimestreamSchemasResultSet();
+  public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
+    return new TimestreamSchemasResultSet(this.connection, schemaPattern);
   }
 
   @Override
@@ -522,7 +521,7 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
     String schemaPattern,
     String tableNamePattern,
     String[] types) throws SQLException {
-    return new TimestreamTablesResultSet(connection, catalog, tableNamePattern, types);
+    return new TimestreamTablesResultSet(connection, schemaPattern, tableNamePattern, types);
   }
 
   @Override

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
@@ -16,92 +16,21 @@
 package software.amazon.timestream.jdbc;
 
 import com.amazonaws.services.timestreamquery.model.ColumnInfo;
-import com.amazonaws.services.timestreamquery.model.Datum;
-import com.amazonaws.services.timestreamquery.model.Row;
 import com.google.common.collect.ImmutableList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * ResultSet for returning the list of databases in Timestream.
  */
-public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TimestreamDatabasesResultSet.class);
+public class TimestreamDatabasesResultSet extends TimestreamEmptyBaseResultSet {
   private static final List<ColumnInfo> COLUMNS = ImmutableList.of(
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "TABLE_CAT"));
 
-  private boolean isAfterLast = false;
-
   /**
    * Constructor.
-   *
-   * @param connection the parent connection of the result set.
-   * @throws SQLException if a database access error occurs.
    */
-  TimestreamDatabasesResultSet(TimestreamConnection connection) throws SQLException {
-    super(null, 20);
-    this.rsMeta = createColumnMetadata(COLUMNS);
-
-    populateCurrentRows(connection);
-  }
-
-  @Override
-  public boolean isAfterLast() throws SQLException {
-    verifyOpen();
-    return isAfterLast;
-  }
-
-  @Override
-  public boolean isLast() throws SQLException {
-    verifyOpen();
-    LOGGER.debug("Checking whether the last row of this TimestreamDatabasesResultSet has been reached.");
-    return !isAfterLast && !this.rowItr.hasNext();
-  }
-
-  @Override
-  protected void doClose() {
-    LOGGER.debug("Closed is called on this TimestreamDatabasesResultSet, do nothing as the result set has already been closed.");
-  }
-
-  /**
-   * Retrieve the next page of the results.
-   *
-   * @return {@code true} if there is another page; {@code false} otherwise.
-   */
-  @Override
-  protected boolean doNextPage() {
-    LOGGER.debug("Attempting to retrieve the next page of results. There are no more pages, return false.");
-    this.isAfterLast = true;
-    return false;
-  }
-
-  /**
-   * Map the list of databases into a Timestream Row type to allow reuse of the common ResultSet
-   * retrieval path.
-   *
-   * @param connection The parent connection to retrieve databases from.
-   * @throws SQLException if there is an error listing the databases.
-   */
-  private void populateCurrentRows(TimestreamConnection connection) throws SQLException {
-    final List<String> databases = new ArrayList<>();
-    try (Statement statement = connection.createStatement()) {
-      LOGGER.debug("Retrieving a list of databases.");
-      try (ResultSet rs = statement.executeQuery("SHOW DATABASES")) {
-        while (rs.next()) {
-          databases.add(rs.getString(1));
-        }
-      }
-    }
-    LOGGER.debug("Retrieved {} databases.", databases.size());
-    this.rowItr = databases.stream()
-      .map(d -> new Datum().withScalarValue(d))
-      .map(d -> new Row().withData(d))
-      .iterator();
+  public TimestreamDatabasesResultSet() {
+    super(COLUMNS);
   }
 }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
@@ -15,22 +15,100 @@
 package software.amazon.timestream.jdbc;
 
 import com.amazonaws.services.timestreamquery.model.ColumnInfo;
+import com.amazonaws.services.timestreamquery.model.Datum;
+import com.amazonaws.services.timestreamquery.model.Row;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Result set to return an empty list of schemas in Timestream.
  */
-public class TimestreamSchemasResultSet extends TimestreamEmptyBaseResultSet {
+public class TimestreamSchemasResultSet extends TimestreamBaseResultSet {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimestreamDatabasesResultSet.class);
+  private static final Datum NULL_DATUM = new Datum().withNullValue(Boolean.TRUE);
   private static final List<ColumnInfo> COLUMNS = ImmutableList.of(
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "TABLE_SCHEM"),
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "TABLE_CATALOG"));
 
+  private boolean isAfterLast = false;
+
   /**
    * Constructor.
+   *
+   * @param connection the parent connection of the result set.
+   * @param schemaPattern the SchemaPattern. null if not provided
+   * @throws SQLException if a database access error occurs.
    */
-  public TimestreamSchemasResultSet() {
-    super(COLUMNS);
+  TimestreamSchemasResultSet(TimestreamConnection connection, String schemaPattern) throws SQLException {
+    super(null, 20);
+    this.rsMeta = createColumnMetadata(COLUMNS);
+
+    populateCurrentRows(connection, schemaPattern);
+  }
+
+  @Override
+  public boolean isAfterLast() throws SQLException {
+    verifyOpen();
+    return isAfterLast;
+  }
+
+  @Override
+  public boolean isLast() throws SQLException {
+    verifyOpen();
+    LOGGER.debug("Checking whether the last row of this TimestreamSchemasResultSet has been reached.");
+    return !isAfterLast && !this.rowItr.hasNext();
+  }
+
+  @Override
+  protected void doClose() {
+    LOGGER.debug("Closed is called on this TimestreamSchemasResultSet, do nothing as the result set has already been closed.");
+  }
+
+  /**
+   * Retrieve the next page of the results.
+   *
+   * @return {@code true} if there is another page; {@code false} otherwise.
+   */
+  @Override
+  protected boolean doNextPage() {
+    LOGGER.debug("Attempting to retrieve the next page of results. There are no more pages, return false.");
+    this.isAfterLast = true;
+    return false;
+  }
+
+  /**
+   * Map the list of databases into a Timestream Row type to allow reuse of the common ResultSet
+   * retrieval path.
+   *
+   * @param connection The parent connection to retrieve databases from.
+   * @param schemaPattern The schemaPattern to filter databases
+   * @throws SQLException if there is an error listing the databases.
+   */
+  private void populateCurrentRows(TimestreamConnection connection, String schemaPattern) throws SQLException {
+    final List<Row> databases = new ArrayList<>();
+    try (Statement statement = connection.createStatement()) {
+      LOGGER.debug("Retrieving a list of databases." + (Strings.isNullOrEmpty(schemaPattern) ? "" : " Schema pattern is " + schemaPattern + "."));
+      final String query = "SHOW DATABASES" +
+              (Strings.isNullOrEmpty(schemaPattern) ? "" : " LIKE '" + schemaPattern + "'");
+      try (ResultSet rs = statement.executeQuery(query)) {
+        while (rs.next()) {
+          databases.add(new Row().withData(
+                  new Datum().withScalarValue(rs.getString(1)),
+                  NULL_DATUM
+          ));
+        }
+      }
+    }
+    LOGGER.debug("Retrieved {} databases.", databases.size());
+
+    this.rowItr = databases.iterator();
   }
 }

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -18,4 +18,12 @@
     <Class name="software.amazon.timestream.jdbc.TimestreamTablesResultSet"/>
     <Method name="populateCurrentRows"/>
   </Match>
+  <Match>
+    <!--The exclude is added as currently driver does not support the prepared statement.
+    This is not a new exclude, as it has already been added for populateCurrentRows for
+    TimestreamTablesResultSet in this file.-->
+    <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamSchemasResultSet"/>
+    <Method name="populateCurrentRows" params="software.amazon.timestream.jdbc.TimestreamConnection,java.lang.String" returns="void" />
+  </Match>
 </FindBugsFilter>

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -19,7 +19,9 @@
     <Method name="populateCurrentRows"/>
   </Match>
   <Match>
-    <!--The exclude is added as currently driver does not support the prepared statement.
+    <!--The proper solution to this issue would be using Prepared Statement to construct
+    a pre-compiled SQL query, and currently the driver does not support Prepared Statement,
+    so the exclude is added.
     This is not a new exclude, as it has already been added for populateCurrentRows for
     TimestreamTablesResultSet in this file.-->
     <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -201,6 +201,18 @@ class TimestreamDatabaseMetaDataTest {
     }
   }
 
+  /**
+   * Checks that empty result set is returned for empty database
+   */
+  @Test
+  void testGetTablesWithEmptyDatabase() throws SQLException {
+    initializeWithResult();
+    try (ResultSet resultSet = dbMetaData
+            .getTables(null, "emptyDB", null, null)) {
+      Assertions.assertFalse(resultSet.next());
+    }
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"%test%", "_estTabl_", "%Ta_le"})
   void testGetTablesWithTableNamePattern(String pattern) throws SQLException {
@@ -304,6 +316,13 @@ class TimestreamDatabaseMetaDataTest {
    * @throws SQLException If an error occurs while retrieving the value.
    */
   private void initializeWithResult() throws SQLException {
+    final ResultSet emptyResultSet = Mockito.mock(ResultSet.class);
+    Mockito.when(emptyResultSet.next()).thenReturn(false);
+
+    final ResultSet emptydbResultSet = Mockito.mock(ResultSet.class);
+    Mockito.when(emptydbResultSet.next()).thenReturn(true).thenReturn(false);
+    Mockito.when(emptydbResultSet.getString(1)).thenReturn("emptyDB");
+
     final ResultSet dbResultSet = Mockito.mock(ResultSet.class);
     Mockito.when(dbResultSet.next()).thenReturn(true).thenReturn(false);
     Mockito.when(dbResultSet.getString(1)).thenReturn("testDB");
@@ -312,24 +331,34 @@ class TimestreamDatabaseMetaDataTest {
     Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE '%test%'")).thenReturn(dbResultSet);
     Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE 'testDB'")).thenReturn(dbResultSet);
     Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE '%testDB%'")).thenReturn(dbResultSet);
+    Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE 'emptyDB'")).thenReturn(emptydbResultSet);
+
+    final ResultSet singleTableResultSet = Mockito.mock(ResultSet.class);
+    Mockito.when(singleTableResultSet.next()).thenReturn(true).thenReturn(false);
+    Mockito.when(singleTableResultSet.getString(1)).thenReturn("testTable");
 
     final ResultSet tableResultSet = Mockito.mock(ResultSet.class);
-    Mockito.when(tableResultSet.next()).thenReturn(true).thenReturn(false);
-    Mockito.when(tableResultSet.getString(1)).thenReturn("testTable");
+    Mockito.when(tableResultSet.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+    Mockito.when(tableResultSet.getString(1)).thenReturn("testTable").thenReturn("secondTable");
+
     Mockito.when(mockStatement.executeQuery("SHOW TABLES FROM \"testDB\""))
       .thenReturn(tableResultSet);
     Mockito.when(mockStatement.executeQuery("SHOW TABLES FROM \"testDB\" LIKE '%test%'"))
-      .thenReturn(tableResultSet);
+      .thenReturn(singleTableResultSet);
     Mockito.when(mockStatement.executeQuery("SHOW TABLES FROM \"testDB\" LIKE '_estTabl_'"))
-      .thenReturn(tableResultSet);
+      .thenReturn(singleTableResultSet);
     Mockito.when(mockStatement.executeQuery("SHOW TABLES FROM \"testDB\" LIKE '%Ta_le'"))
-      .thenReturn(tableResultSet);
+      .thenReturn(singleTableResultSet);
+    Mockito.when(mockStatement.executeQuery("SHOW TABLES FROM \"emptyDB\""))
+            .thenReturn(emptyResultSet);
 
     final ResultSet columnsResultSet = Mockito.mock(ResultSet.class);
     Mockito.when(columnsResultSet.next()).thenReturn(true).thenReturn(true).thenReturn(false);
     Mockito.when(columnsResultSet.getString(Mockito.anyInt())).thenReturn("ColName");
     Mockito.when(mockStatement.executeQuery("DESCRIBE \"testDB\".\"testTable\""))
       .thenReturn(columnsResultSet);
+    Mockito.when(mockStatement.executeQuery("DESCRIBE \"testDB\".\"secondTable\""))
+            .thenReturn(columnsResultSet);
   }
 
   /**
@@ -404,16 +433,21 @@ class TimestreamDatabaseMetaDataTest {
    * @throws SQLException If an error occurs while retrieving the value.
    */
   private void testGetTableResult(ResultSet resultSet) throws SQLException {
-    final String[] strings = {"", null, "testDB", "testTable", "TABLE", null, null, null, null,
-      null, null};
+    final String[] string1 = {"", null, "testDB", "testTable", "TABLE", null, null, null, null,
+            null, null};
+    final String[] string2 = {"", null, "testDB", "secondTable", "TABLE", null, null, null, null,
+            null, null};
+    final List<String[]> strings = new ArrayList<>();
+    strings.add(string1);
+    strings.add(string2);
 
     int numRows = 0;
     while (resultSet.next()) {
-      numRows++;
       for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
-        Assertions.assertEquals(strings[i], resultSet.getString(i));
+        Assertions.assertEquals(strings.get(numRows)[i], resultSet.getString(i));
       }
+      numRows++;
     }
-    Assertions.assertEquals(1, numRows);
+    Assertions.assertEquals(2, numRows);
   }
 }

--- a/performancetest/pom.xml
+++ b/performancetest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>software.amazon.timestream</groupId>
     <artifactId>timestream</artifactId>
-    <version>1.0.2</version>
+    <version>2.0.0</version>
   </parent>
 
   <artifactId>performancetest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>software.amazon.timestream</groupId>
   <artifactId>timestream</artifactId>
-  <version>1.0.2</version>
+  <version>2.0.0</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -40,7 +40,7 @@
     <mockito.version>2.28.2</mockito.version>
     <slf4j.version>1.7.24</slf4j.version>
     <timestream.version>1.11.872</timestream.version>
-    <timestream.jdbc.version>1.0.0</timestream.jdbc.version>
+    <timestream.jdbc.version>2.0.0</timestream.jdbc.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
<!--- General summary / title -->
report database name as schema instead of catalog

### Description

<!--- Details of what you changed -->

Summary

- report database name as schema instead of catalog in `getTables` and `getColumns`
- implement `getSchemas()` and `getSchemas(string, string)` to return list of database names
- implement `getCatalogs` to return empty list
- update `supportsSchemasInDataManipulation` to return true, since schemas are now supported
- tests update 
- bump JDBC version from 1.0.2 to 2.0.0, the next major version
- documentation for setting up the driver with Tableau and other BI tools will be in separate PRs

Note that as a result of this change, applications using the Timestream JDBC driver programmatically may break, so the version of the driver is bumped to the next major version, 2.0.0.

Previously, databases are reported as catalogs. This PR changes the driver to report databases as schemas instead. This change allows Tableau to generate correct SQL queries to the driver.

#### How `getSchemas` and `getCatalogs` function before changes in this PR
```mermaid
graph TD
    A[getSchemas] --> |returns| G
    G[empty result set]
    G --> H[TABLE_SCHEM -> null]
    G --> I[TABLE_CATALOG -> null]

    B[getCatalogs] --> |returns| E[database result set]
    E --> J[TABLE_CAT database name]
```

####  How `getSchemas` and `getCatalogs` function after changes in this PR
```mermaid
graph TD
    A[getSchemas] --> |returns| G
    G[database result set]
    G --> H[TABLE_SCHEM -> database name]
    G --> I[TABLE_CATALOG -> null]

    B[getCatalogs] --> |returns| E[empty result set]
    E --> J[TABLE_CAT -> null]
```

#### How table metadata is changed
Before:
```mermaid
graph TD
    A[getTables] --> |returns| G
    G[tables result set]
    G --> H[TABLE_CAT -> database name]
    G --> I[TABLE_SCHEM -> null]
    G --> K[other return values unchanged]
```

After:
```mermaid
graph TD
    A[getTables] --> |returns| G
    G[tables result set]
    G --> H[TABLE_CAT -> null]
    G --> I[TABLE_SCHEM -> database name]
    G --> K[other return values unchanged]
```

#### How column metadata is changed
Before:
```mermaid
graph TD
    A[getColumns] --> |returns| G
    G[columns result set]
    G --> H[TABLE_CAT -> database name]
    G --> I[TABLE_SCHEM -> null]
    G --> K[other return values unchanged]
```

After:
```mermaid
graph TD
    A[getColumns] --> |returns| G
    G[columns result set]
    G --> H[TABLE_CAT -> null]
    G --> I[TABLE_SCHEM -> database name]
    G --> K[other return values unchanged]
```

#### Test Results

With changes in this PR, tdvt had a 10 times increase of success rate, and Tableau is able to generate correct SQL queries to the driver.


Results from running existing JDBC driver:
```
Test Count: 863 tests
        Passed tests: 10
        Failed tests: 853
        Tests run: 863
        Disabled tests: 0
        Skipped tests: 0

Other information:
        Smoke test time: 37.8 seconds
        Main test time: 1175.82 seconds
        Total time: 1213.62 seconds
```

Results from running JDBC driver on this branch:
```
Test Count: 863 tests
        Passed tests: 100
        Failed tests: 763
        Tests run: 863
        Disabled tests: 0
        Skipped tests: 0

Other information:
        Smoke test time: 18.45 seconds
        Main test time: 432.35 seconds
        Total time: 450.8 seconds
```

Summary of Tableau manual testing results

Test Case | Status / Comments / Cause of Failure | Generated SQL Query (if known)
-- | -- | --
Test Case 1. Validate Schema is displayed properly (all database names are displayed) | PASSED <br /> Database names containing “_”, digit, lower case and upper case can display correctly |  
Test Case 2. Tables are displayed correctly when its database is chosen as Schema | PASSED <br /> Tables with names including digits, dash, period, or underscore are displayed correctly. No table is shown for the empty database, which is correct. |  
Test Case 3. Autogenerated SQL queries are correct | CONDITIONALLY PASSED. Colons (":") are not supported by Timestream  in AS statements. The workaround is to manually correct the generated SQL query to remove the colons (":") in AS statements. | Auto-generated query for retrieving `meta_queries_test_db.DevOpsMulti`: <br />```   SELECT "DevOpsMulti"."az" AS "az", "DevOpsMulti"."cpu_utilization" AS "cpu_utilization","DevOpsMulti"."hostname" AS "hostname","DevOpsMulti"."measure_name" AS "measure_name","DevOpsMulti"."memory_utilization" AS "memory_utilization", "DevOpsMulti"."region" AS "region", "DevOpsMulti"."time" AS "time" FROM "meta_queries_test_db"."DevOpsMulti" "DevOpsMulti" LIMIT 10000 ``` <br /> This query works and runs successfully. <br />Auto-generated query for retrieving `data_queries_test_db.TestComplexTypes`:<br /> ```SELECT "TestComplexTypes"."az" AS "az",     "TestComplexTypes"."instance_id" AS "instance_id",    "TestComplexTypes"."measure_name" AS "measure_name",    "TestComplexTypes"."measure_value::double" AS "measure_value::double",      "TestComplexTypes"."region" AS "region",      "TestComplexTypes"."time" AS "time",    "TestComplexTypes"."vpc" AS "vpc"   FROM "data_queries_test_db"."TestComplexTypes" "TestComplexTypes"  LIMIT 10000```<br /> This query does not work because Timestream server does not support queries with colons(:) in AS statements, it is not due to the driver, and server-side change is needed to make it work. 
Test Case 4. Join 2 tables from the same database | PASSED - Able to join meta_queries_test_db.TestColumnsMetadata1 with meta_queries_test_db.Test.ColumnsMetadata |  
Test Case 5. Join 2 tables with the different names from different databases | PASSED - Able to join tables with names including digits, dash, period, or underscore. | 
Test Case 6 a. Join 2 large tables with the same name from different databases | FAILED. Tableau may generate colons (":") in the AS statement, causing query to fail on the server-side, especially when loading large tables. | The initial query that Tableau generated, which works: <br />``` SELECT "DevOpsMulti"."az" AS "az", "DevOpsMulti1"."az" AS "az (DevOpsMulti1)",   "DevOpsMulti"."cpu_utilization" AS "cpu_utilization", "DevOpsMulti1"."cpu_utilization" AS "cpu_utilization (DevOpsMulti1)",    "DevOpsMulti"."hostname" AS "hostname", "DevOpsMulti1"."hostname" AS "hostname (DevOpsMulti1)", "DevOpsMulti"."measure_name" AS "measure_name", "DevOpsMulti1"."measure_name" AS "measure_name (DevOpsMulti1)",  "DevOpsMulti"."memory_utilization" AS "memory_utilization", "DevOpsMulti1"."memory_utilization" AS "memory_utilization (DevOpsMulti1)", "DevOpsMulti"."region" AS "region", "DevOpsMulti1"."region" AS "region (DevOpsMulti1)", "DevOpsMulti"."time" AS "time", "DevOpsMulti1"."time" AS "time (DevOpsMulti1)" FROM "sampleDB_2"."DevOpsMulti" "DevOpsMulti" INNER JOIN "meta_queries_test_db"."DevOpsMulti" "DevOpsMulti1" ON (("DevOpsMulti"."az" = "DevOpsMulti1"."az") AND ("DevOpsMulti"."hostname" = "DevOpsMulti1"."hostname") AND ("DevOpsMulti"."region" = "DevOpsMulti1"."region") AND ("DevOpsMulti"."measure_name" = "DevOpsMulti1"."measure_name"))  LIMIT 100```<br /> The subsequent query that Tableau generated and sent to the JDBC driver, which does not work:<br />``` SELECT SUM(1) AS "cnt:DevOpsMulti_E34B84972C4C458CB4D4BB86AD06DE0B:ok" FROM "sampleDB_2"."DevOpsMulti" "DevOpsMulti" INNER JOIN "meta_queries_test_db"."DevOpsMulti" "DevOpsMulti1" ON (("DevOpsMulti"."az" = "DevOpsMulti1"."az") AND ("DevOpsMulti"."hostname" = "DevOpsMulti1"."hostname") AND ("DevOpsMulti"."region" = "DevOpsMulti1"."region") AND ("DevOpsMulti"."measure_name" = "DevOpsMulti1"."measure_name")) HAVING (COUNT(1) > 0)```<br /> Tableau tried several times to re-run the query above, but all met with failure due to server not supporting queries including colons (“:“) in the AS statement | 
Test Case 6 b. Join 2 tables with the same name from different databases | PASSED - Able to join `data_queries_test_db.TestScalarTypes` and `meta_queries_test_db.TestScalarTypes`.  This test case worked because the tables contain only 4 rows and Tableau did not generate queries including colons in the AS statement. | ```SELECT "TestScalarTypes"."device_id" AS "device_id", "TestScalarTypes1"."device_id" AS "device_id (TestScalarTypes1)", "TestScalarTypes"."device_type" AS "device_type", "TestScalarTypes1"."device_type" AS "device_type (TestScalarTypes1)", "TestScalarTypes"."flag" AS "flag", "TestScalarTypes1"."flag" AS "flag (TestScalarTypes1)",  "TestScalarTypes"."measure_name" AS "measure_name", "TestScalarTypes1"."measure_name" AS "measure_name (TestScalarTypes1)", "TestScalarTypes"."os_version" AS "os_version", "TestScalarTypes1"."os_version" AS "os_version (TestScalarTypes1)", "TestScalarTypes"."rebuffering_ratio" AS "rebuffering_ratio",  "TestScalarTypes1"."rebuffering_ratio" AS "rebuffering_ratio (TestScalarTypes1)",  "TestScalarTypes"."region" AS "region",  "TestScalarTypes1"."region" AS "region (TestScalarTypes1)",  "TestScalarTypes"."time" AS "time",  "TestScalarTypes1"."time" AS "time (TestScalarTypes1)", "TestScalarTypes"."video_startup_time" AS "video_startup_time", "TestScalarTypes1"."video_startup_time" AS "video_startup_time (TestScalarTypes1)" FROM "meta_queries_test_db"."TestScalarTypes" "TestScalarTypes"  INNER JOIN "data_queries_test_db"."TestScalarTypes" "TestScalarTypes1" ON ("TestScalarTypes"."device_id" = "TestScalarTypes1"."device_id") LIMIT 100```
Test Case 7. Columns names and data types are displayed properly for each table | PASSED - Unicode column name displays correctly. Data types varchar, timestamp, boolean, double, and bigint display correctly. |  
Test Case 8. Filter tables using table name sub-strings | PASSED - Able to filter table names using “.”, “-”, “_”, and text (“Multi“). |  

For details of Tableau manual testing results, please refer to [Tableau Manual Testing Documentation](https://github.com/awslabs/amazon-timestream-driver-jdbc/files/10212464/Tableau.Manual.Testing.Doc.Dec-12.pdf)


### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
@mitchell-elholm
@RoyZhang2022
<!-- Any additional reviewers -->