### PR TITLE
Temporary removing logic to retrieve application name

### DIFF
--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
@@ -175,43 +175,9 @@ public class TimestreamDriver implements java.sql.Driver {
      * @return the name of the currently running application.
      */
     private static String getApplicationName() {
-        // What we do is get the process ID of the current process, then check the set of running processes and pick out
+        // Currently not supported
+        // Need to implement to get the process ID of the current process, then check the set of running processes and pick out
         // the one that matches the current process. From there we can grab the name of what is running the process.
-        try {
-            final String pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
-            final boolean isWindows = System.getProperty("os.name").startsWith("Windows");
-
-            if (isWindows) {
-                final Process process = Runtime.getRuntime()
-                    .exec("tasklist /fi \"PID eq " + pid + "\" /fo csv /nh");
-                try (BufferedReader input = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                    final String line = input.readLine();
-                    if (line != null) {
-                        // Omit the surrounding quotes.
-                        return line.substring(1, line.indexOf(",") - 1);
-                    }
-                }
-            } else {
-                final Process process = Runtime.getRuntime().exec("ps -eo pid,comm");
-                try (BufferedReader input = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                    String line;
-                    while ((line = input.readLine()) != null) {
-                        line = line.trim();
-                        if (line.startsWith(pid)) {
-                            return line.substring(line.indexOf(" ") + 1);
-                        }
-                    }
-                }
-            }
-        } catch (Exception err) {
-            // Eat the exception and fall through.
-            LOGGER.warning(
-                "An exception has occurred and ignored while retrieving the caller application name: "
-                    + err.getLocalizedMessage());
-        }
-
         return "Unknown";
     }
 

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
@@ -176,7 +176,7 @@ public class TimestreamDriver implements java.sql.Driver {
      */
     private static String getApplicationName() {
         // Currently not supported.
-        // Need to implement to get the process ID of the current process, then check the set of running processes and pick out
+        // Need to implement logic to get the process ID of the current process, then check the set of running processes and pick out
         // the one that matches the current process. From there we can grab the name of what is running the process.
         return "Unknown";
     }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
@@ -175,7 +175,7 @@ public class TimestreamDriver implements java.sql.Driver {
      * @return the name of the currently running application.
      */
     private static String getApplicationName() {
-        // Currently not supported
+        // Currently not supported.
         // Need to implement to get the process ID of the current process, then check the set of running processes and pick out
         // the one that matches the current process. From there we can grab the name of what is running the process.
         return "Unknown";


### PR DESCRIPTION
*Description of changes:*
Previously, the driver was using logic to retrieve the application name to pass it as a user agent to the Timestream service when establishing the connection. For Windows, this logic passed PID to the OS command, which might be not secured.

This change removes this logic, and the current application name will be set to "Unknown" instead.

The issue to track the implementation of retrieving application name  - https://github.com/awslabs/amazon-timestream-driver-jdbc/issues/28


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
