### PR TITLE
Enhance logic to retrieve application name

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -70,7 +70,7 @@
 
         <!-- Dependency versions -->
         <awssdk.version>1.11.870</awssdk.version>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
         <jsoup.version>1.15.3</jsoup.version>
         <mockito.version>2.28.2</mockito.version>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -127,16 +127,6 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>5.13.0</version>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>5.13.0</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -127,6 +127,16 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>5.13.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <awssdk.version>1.11.870</awssdk.version>
-    <guava.version>29.0-jre</guava.version>
+    <guava.version>32.0.1-jre</guava.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <jsoup.version>1.15.3</jsoup.version>
     <maven.install.version>3.0.0-M1</maven.install.version>


### PR DESCRIPTION
*Issue #, if available:*
Enhance logic to retrieve application name(https://github.com/awslabs/amazon-timestream-driver-jdbc/issues/28)

*Description of changes:*
- Get application name by using `tasklist /fo csv /nh` to get all process info on Windows. Then matching the process ID to get the application name
- Get application name by using `ps -eo pid,comm` to get all process info on Linux and macOS. Then matching the process ID to get the application name
- Fix dependency vulnerability, Bump guava to `32.0.1-jre`
- Update `codeql-action` to v2 for codeql-analysis workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
