### PR TITLE
AT-1467 add GPG documentation and modify plugin to sign jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Upon completion, the page will be redirected back to the `Identity providers` pa
 
 ### Building the fully shaded JAR With All Dependencies Shaded Except SLF4J (amazon-timestream-jdbc-\<version\>-jar-with-all-dependencies.jar)
 To build a fully shaded JAR, comment out the following two lines in the pom file in the [/jdbc/pom.xml](/jdbc/pom.xml) then run `mvn install`.
+#### To build the signed jar the following maven profile should be used: `mvn clean install -Ddeploy`.
 
 ```xml
 <scope>system</scope>
@@ -453,6 +454,14 @@ To use the JAR with no dependencies in a Java application, the following require
 
 ### Building and using the Javadoc JAR to extract the Javadoc HTML files (amazon-timestream-jdbc-\<version\>-javadoc.jar)
 Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract the Javadoc HTML files, use the following command: `jar -xvf amazon-timestream-jdbc-1.0.0-javadoc.jar`
+
+### GPG Installation
+For building signed jar before executing: `mvn clean install -Pdeploy` the following setup should be done
+1. Download and install GPG https://gnupg.org/download/
+2. Generate new key:
+   For GPG version 2.1.17 or greater: `gpg --full-generate-key`
+   For GPG version lower than 2.1.17: `gpg --default-new-key-algo rsa4096 --gen-key`
+3. Export GPG TTY: `export GPG_TTY=$(tty)`
 
 ### Known Issues
 1. Timestream does not support fully qualified table names.

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -78,6 +78,29 @@
         <timestream.version>1.11.872</timestream.version>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -306,19 +329,6 @@
                                 </filter>
                             </filters>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary
Improve build process to have ability build jdbc project without setting up GPG and secrets.
Update documentation to add GPG installation section
Update documentation with the command how to build project with signed/unsigned jar

## Description
The problem occurs when user try to build JDBC project locally without preinstalled and configured GPG.
It throws an error that GPG required for setup. Each time when user building the app the password for GPG token may asked. 

## Related Issue
AT-1467

## Tests performed / created
### Unit tests: 
All existing Unit tests passed

### Manual verification:
1. Build project with command `mvn clean install`
2. Verify that jar file not signed
3. Check maven logs to make sure that GPG-PLUGIN has not been executed

1. Build project with command `mvn clean install -Pdeploy`
2. Verify that jar file signed
3. Check maven logs to make sure that GPG-PLUGIN has been executed and password for token has been asked


## Additional Reviewers
@alexey-temnikov 