### PR TITLE
Update dependency and spotbugs

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -69,10 +69,10 @@
         <argLine>-Duser.timezone=Europe/Paris</argLine>
 
         <!-- Dependency versions -->
-        <awssdk.version>1.11.870</awssdk.version>
+        <awssdk.version>1.12.512</awssdk.version>
         <guava.version>29.0-jre</guava.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
-        <jsoup.version>1.15.3</jsoup.version>
+        <jsoup.version>1.16.1</jsoup.version>
         <mockito.version>2.28.2</mockito.version>
         <slf4j.version>1.7.24</slf4j.version>
         <timestream.version>1.11.872</timestream.version>
@@ -198,7 +198,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.0.4</version>
+                <version>4.7.3.5</version>
                 <configuration>
                     <excludeFilterFile>src/main/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
                     <xmlOutput>true</xmlOutput>

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -18,14 +18,85 @@
     <Class name="software.amazon.timestream.jdbc.TimestreamTablesResultSet"/>
     <Method name="populateCurrentRows"/>
   </Match>
+
+  <!--
+    The errors:
+    Returning a reference to a mutable object value stored in one of the object's fields exposes the internal representation of the object.
+    If instances are accessed by untrusted code, and unchecked changes to the mutable object would compromise security or other important properties, you will need to do something different.
+    Returning a new copy of the object is better approach in many situations.
+
+    The code should allow users to be responsible for changing the state of the objects
+    -->
   <Match>
     <Bug pattern="EI_EXPOSE_REP"/>
-    <Package name="software.amazon.timestream.jdbc"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="getWarnings"/>
   </Match>
   <Match>
-    <Bug pattern="EI_EXPOSE_REP2"/>
-    <Package name="software.amazon.timestream.jdbc"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="getResultSet"/>
   </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="getConnection"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="executeQuery"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamPooledConnection"/>
+    <Method name="getConnection"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDriver"/>
+    <Method name="getParentLogger"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDatabaseMetaData"/>
+    <Method name="getConnection"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDataSource"/>
+    <Method name="getParentLogger"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamConnection"/>
+    <Method name="getWarnings"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamConnection"/>
+    <Method name="getTypeMap"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamConnection"/>
+    <Method name="getMetaData"/>
+  </Match>
+
+  <!--
+  The errors:
+  This code stores a reference to an externally mutable object into the internal representation of the object.
+  If instances are accessed by untrusted code, and unchecked changes to the mutable object would compromise security or other important properties,
+  you will need to do something different. Storing a copy of the object is better approach in many situations.
+
+  The code should allow to set external connection to the internal representation
+  -->
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDatabaseMetaData"/>
+    <Method name="&lt;init&gt;"/>
+  </Match>
+
   <Match>
     <!--The proper solution to this issue would be using Prepared Statement to construct
     a pre-compiled SQL query, and currently the driver does not support Prepared Statement,

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -19,6 +19,14 @@
     <Method name="populateCurrentRows"/>
   </Match>
   <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Package name="software.amazon.timestream.jdbc"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Package name="software.amazon.timestream.jdbc"/>
+  </Match>
+  <Match>
     <!--The proper solution to this issue would be using Prepared Statement to construct
     a pre-compiled SQL query, and currently the driver does not support Prepared Statement,
     so the exclude is added.


### PR DESCRIPTION
## Summary
The build uses old dependencies that have vulnerability issues.
The spotbugs dependency has failed to build for Java greater than 1.8.

## Description
The dependency has been updated for aws core and jsoup and spotbugs.
The new version introduces errors for getters that result must be immutable. 
That condition has been added to ignore because the getters should provide not clonable links

## Tests performed/created
### Unit tests: 
All existing Unit tests passed

### Manual verification:
1. Change java to 1.8: `export JAVA_HOME=`/usr/libexec/java_home -v 1.8``
2. Build the project with the command `mvn clean install`
3. Verify that all tests passed and build successful

-------

1. Change java to 1.8: `export JAVA_HOME=`/usr/libexec/java_home -v 11``
2. Build the project with the command `mvn clean install`
3. Verify that all tests passed and build successful

-------

1. Change java to 1.8: `export JAVA_HOME=`/usr/libexec/java_home -v 16``
2. Build the project with the command `mvn clean install`
3. Verify that all tests passed and build successful


## Additional Reviewers
@alexey-temnikov 