### PR TITLE
Add Support for Region Override with Endpoint Discovery

### DIFF
--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/ConnectionTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/ConnectionTest.java
@@ -83,6 +83,46 @@ class ConnectionTest {
   }
 
   @Test
+  void testConnectionWithRegionOverride() throws SQLException {
+    final Properties properties = new Properties();
+    final String urlWithRegion = Constants.URL + "://Region=us-east-1";
+
+    // URL should override property value for region.
+    properties.put("region", "us-west-2");
+
+    try (Connection connection = DriverManager.getConnection(urlWithRegion, properties)) {
+      validateConnection(
+          connection,
+          EXPECTED_DEFAULT_CONNECTION_URL
+      );
+    }
+
+    final TimestreamDataSource dataSource = new TimestreamDataSource();
+    dataSource.setRegion("us-east-1");
+    try (Connection connection = dataSource.getConnection()) {
+      validateConnection(
+          connection,
+          EXPECTED_DEFAULT_CONNECTION_URL
+      );
+    }
+  }
+
+  @Test
+  void testConnectionWithEmptyRegion() {
+    final Properties properties = new Properties();
+    final String urlWithEmptyRegion = Constants.URL + "://Region=";
+
+    Assertions.assertThrows(
+        SQLException.class,
+        () -> DriverManager.getConnection(urlWithEmptyRegion, properties));
+
+    final TimestreamDataSource dataSource = new TimestreamDataSource();
+    dataSource.setEndpoint(urlWithEmptyRegion);
+    dataSource.setRegion("");
+    Assertions.assertThrows(SQLException.class, dataSource::getConnection);
+  }
+
+  @Test
   void testConnectionWithSDKOptions() throws SQLException {
     final Properties properties = new Properties();
     properties.setProperty("RequestTimeout", "1200");

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
@@ -16,6 +16,7 @@
 package software.amazon.timestream.jdbc;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.util.StringUtils;
 import com.google.common.annotations.VisibleForTesting;
 
 import javax.sql.ConnectionEvent;
@@ -712,13 +713,16 @@ public class TimestreamDataSource implements javax.sql.DataSource,
         throw new SQLException(error);
       }
 
-      if (this.region == null) {
+      if (StringUtils.isNullOrEmpty(this.region)) {
         final String error = Error.lookup(Error.MISSING_SERVICE_REGION);
         LOGGER.severe(error);
         throw new SQLException(error);
       }
 
       properties.put(TimestreamConnectionProperty.ENDPOINT.getConnectionProperty(), this.endpoint);
+    }
+
+    if (!StringUtils.isNullOrEmpty(this.region)) {
       properties.put(TimestreamConnectionProperty.REGION.getConnectionProperty(), this.region);
     }
 

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDataSourceTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDataSourceTest.java
@@ -105,6 +105,24 @@ class TimestreamDataSourceTest {
   }
 
   @Test
+  void testDataSourceWithEndpointDiscoveryAndRegion() throws SQLException {
+    final ArgumentCaptor<Properties> propertiesArgumentCaptor = ArgumentCaptor.forClass(Properties.class);
+    final MockTimestreamDataSource mockTimestreamDataSource = new MockTimestreamDataSource(
+        mockTimestreamConnection);
+
+    final Properties expected = new Properties();
+    expected.put(TimestreamConnectionProperty.REGION.getConnectionProperty(), "east");
+
+    mockTimestreamDataSource.setRegion("east");
+    mockTimestreamDataSource.getConnection();
+    Mockito.verify(mockTimestreamConnection).setClientInfo(propertiesArgumentCaptor.capture());
+
+    final Properties constructedConnectionProperties = propertiesArgumentCaptor.getValue();
+    Assertions.assertNotNull(constructedConnectionProperties);
+    Assertions.assertEquals(expected, constructedConnectionProperties);
+  }
+
+  @Test
   void testDataSourceWithEmptyEndpoint() {
     final MockTimestreamDataSource mockTimestreamDataSource = new MockTimestreamDataSource(
       mockTimestreamConnection);


### PR DESCRIPTION
## Summary
Add Support for region use with endpoint discovery.

## Description
Users should be able to override the region for a connection with the URL and endpoint discovery. Prior to fix when using endpoint discovery the region would not be set.

## Related Issue
Issue: [34](https://github.com/awslabs/amazon-timestream-driver-jdbc/issues/34)

## Tests performed/created
Following Tests has been executed manually:
-  Tested in demo application ✅ 
```
    TimestreamDataSource timestreamDataSource = new TimestreamDataSource();
    timestreamDataSource.setRegion("us-west-2");
    
    try (Connection connection = timestreamDataSource.getConnection("AccessKey", "AccessSecret")) {
        connection.getMetaData();
        Statement statement = connection.createStatement();
        ResultSet resultSet = statement.executeQuery("SELECT * FROM \"demoDB\".\"demoTable\" ORDER BY time DESC LIMIT 10 ");
        statement.close();
        while (resultSet.next()) {
            System.out.println(resultSet);
        }
    }
```
