### PR TITLE
Fix AmazonTimestreamQuery client object leak

### DIFF
--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamConnection.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamConnection.java
@@ -322,6 +322,8 @@ public class TimestreamConnection implements java.sql.Connection {
     } catch (Exception e) {
       LOGGER.error("Connection is no longer valid: {}", e.getMessage());
       return false;
+    } finally {
+      client.shutdown();
     }
   }
 


### PR DESCRIPTION
*Issue #19 *

*Description of changes:*

Fix AmazonTimestreamQuery client object leak by calling `shutdown()` after verifying that the connection is valid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
